### PR TITLE
Get position for copied element

### DIFF
--- a/components/element-highlighter/src/js/main.js
+++ b/components/element-highlighter/src/js/main.js
@@ -43,7 +43,7 @@ class ElementHighlighter {
     placeholder.style.marginTop = elementStyles.marginTop;
     placeholder.style.marginBottom = elementStyles.marginBottom;
     placeholder.style.position = elementStyles.position;
-    
+
     elementParent.replaceChild(placeholder, this.element);
 
     // create an overlay

--- a/components/element-highlighter/src/js/main.js
+++ b/components/element-highlighter/src/js/main.js
@@ -42,7 +42,8 @@ class ElementHighlighter {
     placeholder.style.marginRight = elementStyles.marginRight;
     placeholder.style.marginTop = elementStyles.marginTop;
     placeholder.style.marginBottom = elementStyles.marginBottom;
-
+    placeholder.style.position = elementStyles.position;
+    
     elementParent.replaceChild(placeholder, this.element);
 
     // create an overlay

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-components",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In some cases, when the position of the element is fixed, we get jump effect. We should get the position, to prevent copied element from moving content.